### PR TITLE
Remove xid dependency

### DIFF
--- a/conn_data.go
+++ b/conn_data.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/muka/peerjs-go/enums"
 	"github.com/muka/peerjs-go/models"
+	"github.com/muka/peerjs-go/util"
 	"github.com/pion/webrtc/v3"
-	"github.com/rs/xid"
 )
 
 const (
@@ -32,7 +32,7 @@ func NewDataConnection(peerID string, peer *Peer, opts ConnectionOptions) (*Data
 
 	d.id = opts.ConnectionID
 	if d.id == "" {
-		d.id = DataChannelIDPrefix + xid.New().String()
+		d.id = DataChannelIDPrefix + util.RandomToken()
 	}
 
 	d.Label = opts.Label
@@ -322,7 +322,7 @@ func (d *DataConnection) Send(data []byte, chunked bool) error {
 // func (d *DataConnection) sendChunks(raw []byte) {
 // 	panic("sendChunks: binarypack not implemented, please use SerializationTypeRaw")
 // 	// // this method requires a [binarypack] encoding to work
-// 	// chunks := Chunk(raw)
+// 	// chunks := util.Chunk(raw)
 // 	// d.log.Debugf(`DC#%s Try to send %d chunks...`, d.GetID(), len(chunks))
 // 	// for _, chunk := range chunks {
 // 	// 	d.Send(chunk, true)

--- a/conn_media.go
+++ b/conn_media.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/muka/peerjs-go/enums"
 	"github.com/muka/peerjs-go/models"
+	"github.com/muka/peerjs-go/util"
 	"github.com/pion/webrtc/v3"
-	"github.com/rs/xid"
 )
 
 //MediaChannelIDPrefix the media channel connection id prefix
@@ -23,7 +23,7 @@ func NewMediaConnection(id string, peer *Peer, opts ConnectionOptions) (*MediaCo
 
 	m.id = opts.ConnectionID
 	if m.id == "" {
-		m.id = fmt.Sprintf("%s%s", MediaChannelIDPrefix, xid.New().String())
+		m.id = fmt.Sprintf("%s%s", MediaChannelIDPrefix, util.RandomToken())
 	}
 
 	m.localStream = opts.Stream

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/pion/transport v0.12.0 // indirect
 	github.com/pion/webrtc/v3 v3.0.0-beta.14
 	github.com/rs/cors v1.7.0
-	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
-github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=

--- a/options.go
+++ b/options.go
@@ -3,8 +3,8 @@ package peer
 import (
 	"github.com/muka/peerjs-go/enums"
 	"github.com/muka/peerjs-go/models"
+	"github.com/muka/peerjs-go/util"
 	"github.com/pion/webrtc/v3"
-	"github.com/rs/xid"
 )
 
 // NewOptions return Peer options with defaults
@@ -15,7 +15,7 @@ func NewOptions() Options {
 		PingInterval: 1000,
 		Path:         "/",
 		Secure:       true,
-		Token:        xid.New().String(),
+		Token:        util.RandomToken(),
 		Key:          DefaultKey,
 		Configuration: webrtc.Configuration{
 			ICEServers: []webrtc.ICEServer{

--- a/peer_test.go
+++ b/peer_test.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/muka/peerjs-go/server"
+	"github.com/muka/peerjs-go/util"
 	"github.com/pion/webrtc/v3"
-	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 )
 
 func rndName(name string) string {
-	return fmt.Sprintf("%s_%s", name, xid.New().String())
+	return fmt.Sprintf("%s_%s", name, util.RandomToken())
 }
 
 func getTestOpts(serverOpts server.Options) Options {

--- a/server/realm.go
+++ b/server/realm.go
@@ -4,12 +4,12 @@ import (
 	"sync"
 
 	"github.com/muka/peerjs-go/models"
-	"github.com/rs/xid"
+	"github.com/muka/peerjs-go/util"
 )
 
 // ClientIDGenerator default hash generator
 var ClientIDGenerator = func() string {
-	return xid.New().String()
+	return util.RandomToken()
 }
 
 // NewRealm creates a new Realm

--- a/util.go
+++ b/util.go
@@ -1,6 +1,23 @@
 package peer
 
-import "math"
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Seed personal random source - faster and won't mess with global one
+var tokenRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+const tokenChars = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randomToken() string {
+	b := make([]byte, 11) // PeerJS random tokens are 11 chars long
+	for i := range b {
+		b[i] = tokenChars[tokenRand.Intn(len(tokenChars))]
+	}
+	return string(b)
+}
 
 //ChunckedData wraps a data slice with metadata to assemble back the whole data
 type ChunckedData struct {

--- a/util/util.go
+++ b/util/util.go
@@ -1,4 +1,4 @@
-package peer
+package util
 
 import (
 	"math"
@@ -11,7 +11,7 @@ var tokenRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const tokenChars = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-func randomToken() string {
+func RandomToken() string {
 	b := make([]byte, 11) // PeerJS random tokens are 11 chars long
 	for i := range b {
 		b[i] = tokenChars[tokenRand.Intn(len(tokenChars))]

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,4 +1,4 @@
-package peer
+package util
 
 import (
 	"bytes"


### PR DESCRIPTION
[Here's](https://github.com/peers/peerjs/blob/cfc37c7988d8ef3d2c1d7b6123562dd2af59defc/lib/util.ts#L145-L149) how PeerJS generates tokens.

This PR removes the unnecessary dependency on xid, and generates similar tokens, but with a more understandable method.

Untested right now, but should work.