### PR TITLE
Missing a function for TLS and a minor fix

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//NewOptions create default options
+// NewOptions create default options
 func NewOptions() Options {
 	return Options{
 		Port:            9000,
@@ -29,7 +29,7 @@ func NewOptions() Options {
 	}
 }
 
-//Options peer server options
+// Options peer server options
 type Options struct {
 	Port            int
 	Host            string
@@ -43,7 +43,7 @@ type Options struct {
 	CleanupOutMsgs  int
 }
 
-//HTTPServer peer server
+// HTTPServer peer server
 type HTTPServer struct {
 	opts           Options
 	realm          IRealm
@@ -208,7 +208,7 @@ func (h *HTTPServer) registerHandlers() error {
 	return nil
 }
 
-//Start start the HTTP server
+// Start start the HTTP server
 func (h *HTTPServer) Start() error {
 
 	err := h.registerHandlers()
@@ -234,7 +234,33 @@ func (h *HTTPServer) Start() error {
 	return h.http.ListenAndServe()
 }
 
-//Stop stops the HTTP server
+// Start start the HTTPS server
+func (h *HTTPServer) StartTLS(certFile, keyFile string) error {
+
+	err := h.registerHandlers()
+	if err != nil {
+		return err
+	}
+
+	c := cors.New(cors.Options{
+		AllowedOrigins:   []string{"*"},
+		AllowCredentials: true,
+	})
+
+	handler := c.Handler(h.router)
+
+	h.http = &http.Server{
+		Addr:           fmt.Sprintf("%s:%d", h.opts.Host, h.opts.Port),
+		Handler:        handler,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	return h.http.ListenAndServeTLS(certFile, keyFile)
+}
+
+// Stop stops the HTTP server
 func (h *HTTPServer) Stop() error {
 	return h.http.Close()
 }

--- a/server/http.go
+++ b/server/http.go
@@ -180,7 +180,7 @@ func (h *HTTPServer) registerHandlers() error {
 
 	// handle WS route
 	err = baseRoute.
-		Path(fmt.Sprintf("/%s", h.opts.Key)).
+		Path("/peerjs").
 		Handler(h.auth.WSHandler(h.wss.Handler())).
 		Methods("GET").GetError()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//New creates a new PeerServer
+// New creates a new PeerServer
 func New(opts Options) *PeerServer {
 
 	s := new(PeerServer)
@@ -34,7 +34,7 @@ func New(opts Options) *PeerServer {
 	return s
 }
 
-//PeerServer wrap the peer server functionalities
+// PeerServer wrap the peer server functionalities
 type PeerServer struct {
 	emitter.Emitter
 	log                    *logrus.Entry
@@ -99,6 +99,24 @@ func (p *PeerServer) Start() error {
 	var err error
 	go func() {
 		err = p.http.Start()
+		if err != nil {
+			p.Emit("error", err)
+		}
+	}()
+
+	<-time.After(time.Millisecond * 500)
+	if err == nil {
+		p.log.Infof("Peer server started (:%d)", p.http.opts.Port)
+	}
+	return err
+}
+
+// Start start the TLS peer server
+func (p *PeerServer) StartTLS(certFile, keyFile string) error {
+
+	var err error
+	go func() {
+		err = p.http.StartTLS(certFile, keyFile)
 		if err != nil {
 			p.Emit("error", err)
 		}


### PR DESCRIPTION
Hi, 

I wanted to migrate from peerjs-server to peerjs-go/server, and I found some minor problems with the server.

1. The first difficulty that I encountered was the missing TLS option and for that reason, I created StartTLS method.
2. The second issue was with the websocket path, where the Go's peerjs client and the older JS client were trying to call GET `wss://<website>/<path>/peerjs`, but the Go's server was creating a handler for `wss://<website>/<path>/<key>`. However, I don't know whether the second issue is a bug or a feature on how the peerjs protocol will work now on.

I fixed them for my side project, and I hope you like my improvements.